### PR TITLE
[VIDEO.LA.2.0.r1] Kbuild: Replace real current folder with our source folder

### DIFF
--- a/Kbuild
+++ b/Kbuild
@@ -2,7 +2,7 @@
 
 KBUILD_CPPFLAGS += -DCONFIG_MSM_MMRM=1
 
-VIDEO_ROOT = $(shell pwd)/techpack/video
+VIDEO_ROOT = $(srctree)/techpack/video
 
 ifeq ($(CONFIG_ARCH_WAIPIO), y)
 include $(VIDEO_ROOT)/config/waipio_video.conf


### PR DESCRIPTION
We build kernel with symlink to source.
Fix the Kbuild to use the symlink.

Signed-off-by: Martin Botka <martin.botka@somainline.org>