### PR TITLE
[9.16.r1] vidc: hfi_iris2: Fix -Wpointer-to-int-cast

### DIFF
--- a/msm/vidc/hfi_iris2.c
+++ b/msm/vidc/hfi_iris2.c
@@ -167,7 +167,7 @@ void __setup_ucregion_memory_map_iris2(struct venus_hfi_device *device, u32 sid)
 				(u32)device->qdss.align_device_addr, sid);
 	/* update queues vaddr for debug purpose */
 	__write_register(device, CPU_CS_VCICMDARG0_IRIS2,
-		(u32)device->iface_q_table.align_virtual_addr, sid);
+		(uintptr_t)device->iface_q_table.align_virtual_addr, sid);
 	__write_register(device, CPU_CS_VCICMDARG1_IRIS2,
 		(u32)((u64)device->iface_q_table.align_virtual_addr >> 32),
 		sid);


### PR DESCRIPTION
vidc: hfi_iris2: Fix -Wpointer-to-int-cast

msm/vidc/hfi_iris2.c:170:3: warning: cast to smaller integer type 'u32' (aka 'unsigned int') from 'u8 *' (aka 'unsigned char *') [-Wpointer-to-int-cast]\n" error, forbidden warning: hfi_iris2.c:170