### PR TITLE
[2.0.r1] Built-in compilation changes

### DIFF
--- a/Kbuild
+++ b/Kbuild
@@ -41,7 +41,7 @@ LINUXINCLUDE    += -I$(VIDEO_ROOT)/driver/vidc/inc \
 USERINCLUDE     += -I$(VIDEO_ROOT)/include/uapi/vidc/media \
                    -I$(VIDEO_ROOT)/include/uapi/vidc
 
-obj-m += msm_video.o
+obj-y += msm_video.o
 
 ifeq ($(CONFIG_MSM_VIDC_WAIPIO), y)
 msm_video-objs += driver/platform/waipio/src/msm_vidc_waipio.o

--- a/Kbuild
+++ b/Kbuild
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
+VIDEO_ROOT := $(srctree)/techpack/video
+
 KBUILD_CPPFLAGS += -DCONFIG_MSM_MMRM=1
 
 ifeq ($(CONFIG_ARCH_WAIPIO), y)

--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,7 @@
 
 KBUILD_OPTIONS+= VIDEO_ROOT=$(KERNEL_SRC)/$(M)
 
-VIDEO_COMPILE_TIME = $(shell date)
-VIDEO_COMPILE_BY = $(shell whoami | sed 's/\\/\\\\/')
-VIDEO_COMPILE_HOST = $(shell uname -n)
-VIDEO_GEN_PATH = $(VIDEO_ROOT)/driver/vidc/inc/video_generated_h
-
-all: modules
-
-$(VIDEO_GEN_PATH): $(shell find . -type f \( -iname \*.c -o -iname \*.h -o -iname \*.mk \))
-	echo '#define VIDEO_COMPILE_TIME "$(VIDEO_COMPILE_TIME)"' > $(VIDEO_GEN_PATH)
-	echo '#define VIDEO_COMPILE_BY "$(VIDEO_COMPILE_BY)"' >> $(VIDEO_GEN_PATH)
-	echo '#define VIDEO_COMPILE_HOST "$(VIDEO_COMPILE_HOST)"' >> $(VIDEO_GEN_PATH)
-
-modules: $(VIDEO_GEN_PATH)
+all:
 	$(MAKE) -C $(KERNEL_SRC) M=$(M) modules $(KBUILD_OPTIONS)
 
 modules_install:

--- a/driver/vidc/src/msm_vidc.c
+++ b/driver/vidc/src/msm_vidc.c
@@ -22,8 +22,6 @@
 #include "venus_hfi_response.h"
 #include "msm_vidc.h"
 
-extern const char video_banner[];
-
 #define MSM_VIDC_DRV_NAME "msm_vidc_driver"
 #define MSM_VIDC_BUS_NAME "platform:msm_vidc_bus"
 
@@ -859,7 +857,7 @@ void *msm_vidc_open(void *vidc_core, u32 session_type)
 	struct msm_vidc_core *core;
 	int i = 0;
 
-	d_vpr_h("%s: %s\n", __func__, video_banner);
+	d_vpr_h("%s()\n", __func__);
 	core = vidc_core;
 	if (!core) {
 		d_vpr_e("%s: invalid params\n", __func__);

--- a/driver/vidc/src/msm_vidc_debug.c
+++ b/driver/vidc/src/msm_vidc_debug.c
@@ -379,7 +379,7 @@ static const struct file_operations stability_fops = {
 	.write = trigger_stability_write,
 };
 
-struct dentry* msm_vidc_debugfs_init_drv()
+struct dentry* msm_vidc_debugfs_init_drv(void)
 {
 	struct dentry *dir = NULL;
 

--- a/driver/vidc/src/msm_vidc_probe.c
+++ b/driver/vidc/src/msm_vidc_probe.c
@@ -19,14 +19,10 @@
 #include "msm_vidc_core.h"
 #include "msm_vidc_memory.h"
 #include "venus_hfi.h"
-#include "video_generated_h"
 
 #define BASE_DEVICE_NUMBER 32
 
 struct msm_vidc_core *g_core;
-
-const char video_banner[] = "Video-Banner: (" VIDEO_COMPILE_BY "@"
-	VIDEO_COMPILE_HOST ") (" VIDEO_COMPILE_TIME ")";
 
 static int msm_vidc_deinit_irq(struct msm_vidc_core *core)
 {
@@ -810,7 +806,7 @@ static int __init msm_vidc_init(void)
 {
 	int rc = 0;
 
-	d_vpr_h("%s: %s\n", __func__, video_banner);
+	d_vpr_h("%s()\n", __func__);
 
 	rc = platform_driver_register(&msm_vidc_driver);
 	if (rc) {

--- a/driver/vidc/src/venus_hfi.c
+++ b/driver/vidc/src/venus_hfi.c
@@ -2434,7 +2434,7 @@ static int __load_fw_to_memory(struct platform_device *pdev,
 	phys = res.start;
 	res_size = (size_t)resource_size(&res);
 
-	rc = request_firmware(&firmware, firmware_name, &pdev->dev);
+	rc = request_firmware_direct(&firmware, firmware_name, &pdev->dev);
 	if (rc) {
 		d_vpr_e("%s: failed to request fw \"%s\", error %d\n",
 			__func__, firmware_name, rc);


### PR DESCRIPTION
Minimum set of changes required for built-in compilation.
~~At this moment, the driver has a race condition, it tries to load the firmware before the FS is ready, fails and stops probing.
Please don't merge this yet.~~

Please note that for HW video (de/en)coding we need proprietary vendor.qti.media.c2/libqcodec2 blobs in our ODM.